### PR TITLE
feat(protoc-gen-openapi): remove path parameters from body

### DIFF
--- a/cmd/protoc-gen-openapi/examples/google/example/library/v1/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/google/example/library/v1/openapi.yaml
@@ -269,7 +269,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/MoveBookRequest'
+                            $ref: '#/components/schemas/MoveBookRequestBody'
                 required: true
             responses:
                 "200":
@@ -302,7 +302,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/MergeShelvesRequest'
+                            $ref: '#/components/schemas/MergeShelvesRequestBody'
                 required: true
             responses:
                 "200":
@@ -370,28 +370,20 @@ components:
                     type: string
                     description: A token to retrieve next page of results. Pass this value in the [ListShelvesRequest.page_token][google.example.library.v1.ListShelvesRequest.page_token] field in the subsequent call to `ListShelves` method to retrieve the next page of results.
             description: Response message for LibraryService.ListShelves.
-        MergeShelvesRequest:
+        MergeShelvesRequestBody:
             required:
-                - name
                 - other_shelf_name
             type: object
             properties:
-                name:
-                    type: string
-                    description: The name of the shelf we're adding books to.
                 other_shelf_name:
                     type: string
                     description: The name of the shelf we're removing books from and deleting.
             description: Describes the shelf being removed (other_shelf_name) and updated (name) in this merge.
-        MoveBookRequest:
+        MoveBookRequestBody:
             required:
-                - name
                 - other_shelf_name
             type: object
             properties:
-                name:
-                    type: string
-                    description: The name of the book to move.
                 other_shelf_name:
                     type: string
                     description: The name of the destination shelf.

--- a/cmd/protoc-gen-openapi/examples/google/example/library/v1/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/google/example/library/v1/openapi_json.yaml
@@ -269,7 +269,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/MoveBookRequest'
+                            $ref: '#/components/schemas/MoveBookRequestBody'
                 required: true
             responses:
                 "200":
@@ -302,7 +302,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/MergeShelvesRequest'
+                            $ref: '#/components/schemas/MergeShelvesRequestBody'
                 required: true
             responses:
                 "200":
@@ -370,28 +370,20 @@ components:
                     type: string
                     description: A token to retrieve next page of results. Pass this value in the [ListShelvesRequest.page_token][google.example.library.v1.ListShelvesRequest.page_token] field in the subsequent call to `ListShelves` method to retrieve the next page of results.
             description: Response message for LibraryService.ListShelves.
-        MergeShelvesRequest:
+        MergeShelvesRequestBody:
             required:
-                - name
                 - otherShelfName
             type: object
             properties:
-                name:
-                    type: string
-                    description: The name of the shelf we're adding books to.
                 otherShelfName:
                     type: string
                     description: The name of the shelf we're removing books from and deleting.
             description: Describes the shelf being removed (other_shelf_name) and updated (name) in this merge.
-        MoveBookRequest:
+        MoveBookRequestBody:
             required:
-                - name
                 - otherShelfName
             type: object
             properties:
-                name:
-                    type: string
-                    description: The name of the book to move.
                 otherShelfName:
                     type: string
                     description: The name of the destination shelf.

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
@@ -21,7 +21,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/Message'
+                            $ref: '#/components/schemas/UpdateMessageRequestBody'
                 required: true
             responses:
                 "200":
@@ -81,5 +81,36 @@ components:
                     format: int64
                 label:
                     type: string
+        UpdateMessageRequestBody:
+            type: object
+            properties:
+                another_message:
+                    $ref: '#/components/schemas/AnotherMessage'
+                sub_message:
+                    $ref: '#/components/schemas/Message_SubMessage'
+                string_list:
+                    type: array
+                    items:
+                        type: string
+                sub_message_list:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message_SubMessage'
+                object_list:
+                    type: array
+                    items:
+                        type: object
+                strings_map:
+                    type: object
+                    additionalProperties:
+                        type: string
+                sub_messages_map:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/Message_SubMessage'
+                objects_map:
+                    type: object
+                    additionalProperties:
+                        type: object
 tags:
     - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
@@ -21,7 +21,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/Message'
+                            $ref: '#/components/schemas/UpdateMessageRequestBody'
                 required: true
             responses:
                 "200":
@@ -81,5 +81,36 @@ components:
                     format: int64
                 label:
                     type: string
+        UpdateMessageRequestBody:
+            type: object
+            properties:
+                anotherMessage:
+                    $ref: '#/components/schemas/AnotherMessage'
+                subMessage:
+                    $ref: '#/components/schemas/Message_SubMessage'
+                stringList:
+                    type: array
+                    items:
+                        type: string
+                subMessageList:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Message_SubMessage'
+                objectList:
+                    type: array
+                    items:
+                        type: object
+                stringsMap:
+                    type: object
+                    additionalProperties:
+                        type: string
+                subMessagesMap:
+                    type: object
+                    additionalProperties:
+                        $ref: '#/components/schemas/Message_SubMessage'
+                objectsMap:
+                    type: object
+                    additionalProperties:
+                        type: object
 tags:
     - name: Messaging

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi.yaml
@@ -43,7 +43,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/Message'
+                            $ref: '#/components/schemas/CreateMessageRequestBody'
                 required: true
             responses:
                 "200":
@@ -78,6 +78,16 @@ paths:
                                 $ref: '#/components/schemas/Message'
 components:
     schemas:
+        CreateMessageRequestBody:
+            type: object
+            properties:
+                user_id:
+                    type: integer
+                    format: uint64
+                content:
+                    type: string
+                maybe:
+                    type: string
         Message:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
@@ -43,7 +43,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/Message'
+                            $ref: '#/components/schemas/CreateMessageRequestBody'
                 required: true
             responses:
                 "200":
@@ -78,6 +78,16 @@ paths:
                                 $ref: '#/components/schemas/Message'
 components:
     schemas:
+        CreateMessageRequestBody:
+            type: object
+            properties:
+                userId:
+                    type: integer
+                    format: uint64
+                content:
+                    type: string
+                maybe:
+                    type: string
         Message:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi.yaml
@@ -113,7 +113,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/Message'
+                            $ref: '#/components/schemas/CreateMessageRequestBody'
                 required: true
             responses:
                 "200":
@@ -247,6 +247,46 @@ components:
                   items:
                     $ref: '#/components/schemas/AnyJSONValue'
             description: AnyJSONValue is a "catch all" type that can hold any JSON value, except null as this is not allowed in OpenAPI
+        CreateMessageRequestBody:
+            type: object
+            properties:
+                string_type:
+                    type: string
+                recursive_type:
+                    $ref: '#/components/schemas/RecursiveParent'
+                embedded_type:
+                    $ref: '#/components/schemas/Message_EmbMessage'
+                sub_type:
+                    $ref: '#/components/schemas/SubMessage'
+                repeated_type:
+                    type: array
+                    items:
+                        type: string
+                repeated_sub_type:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SubMessage'
+                repeated_recursive_type:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/RecursiveParent'
+                map_type:
+                    type: object
+                    additionalProperties:
+                        type: string
+                body:
+                    type: object
+                media:
+                    type: array
+                    items:
+                        type: object
+                value_type:
+                    $ref: '#/components/schemas/AnyJSONValue'
+                repeated_value_type:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnyJSONValue'
+                    description: Description of repeated value
         Message:
             type: object
             properties:

--- a/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
+++ b/cmd/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
@@ -113,7 +113,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/Message'
+                            $ref: '#/components/schemas/CreateMessageRequestBody'
                 required: true
             responses:
                 "200":
@@ -247,6 +247,46 @@ components:
                   items:
                     $ref: '#/components/schemas/AnyJSONValue'
             description: AnyJSONValue is a "catch all" type that can hold any JSON value, except null as this is not allowed in OpenAPI
+        CreateMessageRequestBody:
+            type: object
+            properties:
+                stringType:
+                    type: string
+                recursiveType:
+                    $ref: '#/components/schemas/RecursiveParent'
+                embeddedType:
+                    $ref: '#/components/schemas/Message_EmbMessage'
+                subType:
+                    $ref: '#/components/schemas/SubMessage'
+                repeatedType:
+                    type: array
+                    items:
+                        type: string
+                repeatedSubType:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/SubMessage'
+                repeatedRecursiveType:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/RecursiveParent'
+                mapType:
+                    type: object
+                    additionalProperties:
+                        type: string
+                body:
+                    type: object
+                media:
+                    type: array
+                    items:
+                        type: object
+                valueType:
+                    $ref: '#/components/schemas/AnyJSONValue'
+                repeatedValueType:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnyJSONValue'
+                    description: Description of repeated value
         Message:
             type: object
             properties:


### PR DESCRIPTION
When a request has both path parameters and `body: "*"`, the path parameters are being repeated in the body in the resulting OpenAPI spec.
Note how the following example has `name` both in `parameters` and `requestBody` in the generated openapi spec.

**protobuf:**
```protobuf
service LibraryService {
  rpc MergeShelves(MergeShelvesRequest) return (Shelf) {
    option (google.api.http) = {
      post: "/v1/{name=shelves/*}:merge"
      body: "*"
    };
  }
}

// Describes the shelf being removed (other_shelf_name) and updated
// (name) in this merge.
message MergeShelvesRequest {
  // The name of the shelf we're adding books to.
  string name = 1 [
    (google.api.field_behavior) = REQUIRED,
    (google.api.resource_reference).type = "Shelf"
  ];

  // The name of the shelf we're removing books from and deleting.
  string other_shelf_name = 2 [
    (google.api.field_behavior) = REQUIRED,
    (google.api.resource_reference).type = "Shelf"
  ];
}
```

**openapi spec:**
```yaml
paths:
    /v1/shelves/{shelf}:merge:
        post:
            tags:
                - LibraryService
            description: |-
                Merges two shelves by adding all books from the shelf named
                 `other_shelf_name` to shelf `name`, and deletes
                 `other_shelf_name`. Returns the updated shelf.
                 The book ids of the moved books may not be the same as the original books.
                 Returns NOT_FOUND if either shelf does not exist.
                 This call is a no-op if the specified shelves are the same.
            operationId: LibraryService_MergeShelves
            parameters:
                - name: shelf
                  in: path
                  description: The shelf id.
                  required: true
                  schema:
                    type: string
            requestBody:
                content:
                    application/json:
                        schema:
                            $ref: '#/components/schemas/MergeShelvesRequest'
                required: true
            responses:
                "200":
                    description: OK
                    content:
                        application/json:
                            schema:
                                $ref: '#/components/schemas/Shelf'
components:
    schemas:
        MergeShelvesRequest:
            required:
                - name
                - other_shelf_name
            type: object
            properties:
                name:
                    type: string
                    description: The name of the shelf we're adding books to.
                other_shelf_name:
                    type: string
                    description: The name of the shelf we're removing books from and deleting.
            description: Describes the shelf being removed (other_shelf_name) and updated (name) in this merge.
```

According to [use_wildcard_in_body](https://cloud.google.com/endpoints/docs/grpc/transcoding#use_wildcard_in_body), every field **not bound by the path template** should be mapped to the request body.
So fields that are bound by the path template shouldn't be in the request body.

This PR creates a new type named `{method_name}RequestBody` which doesn't contain the fields bound by the path template in these cases.
The resulting openapi spec looks like:
```yaml
paths:
    /v1/shelves/{shelf}:merge:
        post:
            tags:
                - LibraryService
            description: |-
                Merges two shelves by adding all books from the shelf named
                 `other_shelf_name` to shelf `name`, and deletes
                 `other_shelf_name`. Returns the updated shelf.
                 The book ids of the moved books may not be the same as the original books.

                 Returns NOT_FOUND if either shelf does not exist.
                 This call is a no-op if the specified shelves are the same.
            operationId: LibraryService_MergeShelves
            parameters:
                - name: shelf
                  in: path
                  description: The shelf id.
                  required: true
                  schema:
                    type: string
            requestBody:
                content:
                    application/json:
                        schema:
                            $ref: '#/components/schemas/MergeShelvesRequestBody'
                required: true
            responses:
                "200":
                    description: OK
                    content:
                        application/json:
                            schema:
                                $ref: '#/components/schemas/Shelf'
components:
    schemas:
        MergeShelvesRequestBody:
            required:
                - other_shelf_name
            type: object
            properties:
                other_shelf_name:
                    type: string
                    description: The name of the shelf we're removing books from and deleting.
            description: Describes the shelf being removed (other_shelf_name) and updated (name) in this merge.
```